### PR TITLE
Support Data caption

### DIFF
--- a/src/drupalmedia.js
+++ b/src/drupalmedia.js
@@ -1,9 +1,11 @@
 import DrupalMediaEditing from './drupalmediaediting';
 import DrupalMediaUI from './drupalmediaui';
+import DrupalMediaToolbar from './drupalmediatoolbar';
+
 import { Plugin } from 'ckeditor5/src/core';
 
 export default class DrupalMedia extends Plugin {
   static get requires() {
-    return [DrupalMediaEditing, DrupalMediaUI];
+    return [DrupalMediaEditing, DrupalMediaUI, DrupalMediaToolbar];
   }
 }

--- a/src/drupalmediaediting.js
+++ b/src/drupalmediaediting.js
@@ -10,23 +10,35 @@ export default class DrupalMediaEditing extends Plugin {
   }
 
   init() {
-    this.attrs = ['alt', 'data-align', 'data-caption', 'data-entity-type', 'data-entity-uuid', 'data-view-mode'];
+    this.attrs = [
+      'alt',
+      'data-align',
+      'data-caption',
+      'data-entity-type',
+      'data-entity-uuid',
+      'data-view-mode',
+    ];
     const options = this.editor.config.get('drupalMedia');
     if (!options) {
-			return;
+      return;
     }
     const { previewURL, themeError } = options;
     this.previewURL = previewURL;
-    this.themeError = themeError || `
+    this.themeError =
+      themeError ||
+      `
       <p>${this.editor.t(
-        'An error occurred while trying to preview the media. Please save your work and reload this page.'
+        'An error occurred while trying to preview the media. Please save your work and reload this page.',
       )}<p>
     `;
 
     this._defineSchema();
     this._defineConverters();
 
-    this.editor.commands.add('insertDrupalMedia', new InsertDrupalMediaCommand(this.editor));
+    this.editor.commands.add(
+      'insertDrupalMedia',
+      new InsertDrupalMediaCommand(this.editor),
+    );
   }
 
   /**
@@ -45,7 +57,7 @@ export default class DrupalMediaEditing extends Plugin {
     element += '></drupal-media>';
 
     return element;
-  };
+  }
 
   async _fetchPreview(url, query) {
     const response = await fetch(`${url}?${new URLSearchParams(query)}`);
@@ -80,8 +92,8 @@ export default class DrupalMediaEditing extends Plugin {
     conversion.for('dataDowncast').elementToElement({
       model: 'drupalMedia',
       view: {
-        name: 'drupal-media'
-      }
+        name: 'drupal-media',
+      },
     });
 
     conversion.for('editingDowncast').elementToElement({
@@ -107,7 +119,7 @@ export default class DrupalMediaEditing extends Plugin {
         viewWriter.insert(viewWriter.createPositionAt(container, 0), media);
         viewWriter.setCustomProperty('drupalMedia', true, container);
         return toWidget(container, viewWriter, { label: 'media widget' });
-      }
+      },
     });
 
     this.attrs.forEach((attr) => {

--- a/src/drupalmediaediting.js
+++ b/src/drupalmediaediting.js
@@ -102,7 +102,7 @@ export default class DrupalMediaEditing extends Plugin {
           }
         });
         viewWriter.insert(viewWriter.createPositionAt(container, 0), media);
-
+        viewWriter.setCustomProperty('drupalMedia', true, container);
         return toWidget(container, viewWriter, { label: 'media widget' });
       }
     });

--- a/src/drupalmediaediting.js
+++ b/src/drupalmediaediting.js
@@ -31,13 +31,16 @@ export default class DrupalMediaEditing extends Plugin {
 
   /**
    * MediaFilterController::preview requires the saved element.
+   * Not previewing data-caption since it does not get updated by new changes.
    * @todo: is there a better way to get the rendered dataDowncast string?
    */
   _renderElement(modelElement) {
     const attrs = modelElement.getAttributes();
     let element = '<drupal-media';
     for (let attr of attrs) {
-      element += ` ${attr[0]}="${attr[1]}"`;
+      if (attr[0] !== 'data-caption') {
+        element += ` ${attr[0]}="${attr[1]}"`;
+      }
     }
     element += '></drupal-media>';
 

--- a/src/drupalmediatoolbar.js
+++ b/src/drupalmediatoolbar.js
@@ -1,0 +1,27 @@
+import { Plugin } from 'ckeditor5/src/core';
+import { WidgetToolbarRepository } from 'ckeditor5/src/widget';
+
+import { getSelectedDrupalMediaWidget } from './utils';
+
+export default class DrupalMediaToolbar extends Plugin {
+  static get requires() {
+    return [WidgetToolbarRepository];
+  }
+
+  static get pluginName() {
+    return 'DrupalMediaToolbar';
+  }
+
+  afterInit() {
+    const editor = this.editor;
+    const { t } = editor;
+    const widgetToolbarRepository = editor.plugins.get(WidgetToolbarRepository);
+
+    widgetToolbarRepository.register('drupalMedia', {
+      ariaLabel: t('Drupal Media toolbar'),
+      items: editor.config.get('drupalMedia.toolbar') || [],
+      // Get the selected image or an image containing the figcaption with the selection inside.
+      getRelatedElement: (selection) => getSelectedDrupalMediaWidget(selection),
+    });
+  }
+}

--- a/src/drupalmediaui.js
+++ b/src/drupalmediaui.js
@@ -7,7 +7,7 @@ export default class DrupalMediaUI extends Plugin {
     const editor = this.editor;
     const options = this.editor.config.get('drupalMedia');
     if (!options) {
-			return;
+      return;
     }
 
     const { libraryURL, openDialog, dialogSettings = {} } = options;
@@ -22,7 +22,7 @@ export default class DrupalMediaUI extends Plugin {
       buttonView.set({
         label: editor.t('Insert Drupal Media'),
         icon: mediaIcon,
-        tooltip: true
+        tooltip: true,
       });
 
       buttonView.bind('isOn', 'isEnabled').to(command, 'value', 'isEnabled');

--- a/src/insertdrupalmedia.js
+++ b/src/insertdrupalmedia.js
@@ -10,7 +10,10 @@ export default class InsertDrupalMediaCommand extends Command {
   refresh() {
     const model = this.editor.model;
     const selection = model.document.selection;
-    const allowedIn = model.schema.findAllowedParent(selection.getFirstPosition(), 'drupalMedia');
+    const allowedIn = model.schema.findAllowedParent(
+      selection.getFirstPosition(),
+      'drupalMedia',
+    );
     this.isEnabled = allowedIn !== null;
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,17 @@
+import { isWidget } from 'ckeditor5/src/widget';
+
+export function isDrupalMediaWidget(viewElement) {
+
+  return (
+    isWidget(viewElement) && !!viewElement.getCustomProperty('drupalMedia')
+  );
+}
+
+export function getSelectedDrupalMediaWidget(selection) {
+  const viewElement = selection.getSelectedElement();
+  if (viewElement && isDrupalMediaWidget(viewElement)) {
+    return viewElement;
+  }
+
+  return null;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,6 @@
 import { isWidget } from 'ckeditor5/src/widget';
 
 export function isDrupalMediaWidget(viewElement) {
-
   return (
     isWidget(viewElement) && !!viewElement.getCustomProperty('drupalMedia')
   );


### PR DESCRIPTION
This adds a contextual toolbar similar to imageToolbar for drupalMedia.
It is meant to support adding a data-caption,

It accepts toolbar items in the `drupalMedia.toolbar` config when constructing a new CKEditor 5 instance.

```
drupalMedia: {
  toolbar: [],
}
``` 